### PR TITLE
Fixed BaseNews class declaration.

### DIFF
--- a/newsapi/base_news.py
+++ b/newsapi/base_news.py
@@ -7,7 +7,7 @@ class AttrDict(dict):
         self.__dict__ = self
 
 
-class BaseNews:
+class BaseNews(object):
     def __init__(self, API_KEY):
         self.API_KEY = API_KEY
         self.payload = {"apiKey": self.API_KEY}


### PR DESCRIPTION
BaseNews was declared using python old-style type declaration without specifying its base class, object by default However this raises an exception on python 2.7, actually it was tested on 2.7.13:

File “~/.virtualenvs/test/lib/python2.7/site-packages/newsapi/sources.py", line 6, in __init__
    super(Sources, self).__init__(API_KEY)
TypeError: super() argument 1 must be type, not classobj

Please check https://www.python.org/doc/newstyle/ for reference.